### PR TITLE
Skip trying to load kind === external

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -31,6 +31,11 @@ interface NpmResolvedInfo {
   npmPackage: string;
 }
 
+interface ExternalResolvedInfo {
+  kind: "external";
+  specifier: string;
+}
+
 interface ResolveError {
   specifier: string;
   error: string;
@@ -40,7 +45,7 @@ interface DenoInfoJsonV1 {
   version: 1;
   redirects: Record<string, string>;
   roots: string[];
-  modules: Array<NpmResolvedInfo | ResolvedInfo | ResolveError>;
+  modules: Array<NpmResolvedInfo | ResolvedInfo | ExternalResolvedInfo | ResolveError>;
 }
 
 export interface DenoResolveResult {
@@ -51,7 +56,7 @@ export interface DenoResolveResult {
 }
 
 function isResolveError(
-  info: NpmResolvedInfo | ResolvedInfo | ResolveError,
+  info: NpmResolvedInfo | ResolvedInfo | ExternalResolvedInfo | ResolveError,
 ): info is ResolveError {
   return "error" in info && typeof info.error === "string";
 }
@@ -118,6 +123,9 @@ export async function resolveDeno(
       loader: null,
       dependencies: [],
     };
+  } else if (mod.kind === "external") {
+    // Let vite handle this
+    return null;
   }
 
   throw new Error(`Unsupported: ${JSON.stringify(mod, null, 2)}`);

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -45,7 +45,9 @@ interface DenoInfoJsonV1 {
   version: 1;
   redirects: Record<string, string>;
   roots: string[];
-  modules: Array<NpmResolvedInfo | ResolvedInfo | ExternalResolvedInfo | ResolveError>;
+  modules: Array<
+    NpmResolvedInfo | ResolvedInfo | ExternalResolvedInfo | ResolveError
+  >;
 }
 
 export interface DenoResolveResult {

--- a/tests/fixture/inlineExternal.ts
+++ b/tests/fixture/inlineExternal.ts
@@ -1,4 +1,4 @@
-import * as helper from '\0vite/preload-helper.js';
+import * as helper from "\0vite/preload-helper.js";
 
 if (helper !== undefined) {
   console.log("it works");

--- a/tests/fixture/inlineExternal.ts
+++ b/tests/fixture/inlineExternal.ts
@@ -1,0 +1,5 @@
+import * as helper from '\0vite/preload-helper.js';
+
+if (helper !== undefined) {
+  console.log("it works");
+}

--- a/tests/fixture/vite.config.ts
+++ b/tests/fixture/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
         importMapNpm: "npm.ts",
         importMapJsr: "jsr.ts",
         importMapHttp: "http.ts",
+        inlineExternal: 'inlineExternal.ts',
         inlineNpm: "inlineNpm.ts",
         inlineJsr: "inlineJsr.ts",
         inlineHttp: "inlineHttp.ts",

--- a/tests/fixture/vite.config.ts
+++ b/tests/fixture/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
         importMapNpm: "npm.ts",
         importMapJsr: "jsr.ts",
         importMapHttp: "http.ts",
-        inlineExternal: 'inlineExternal.ts',
+        inlineExternal: "inlineExternal.ts",
         inlineNpm: "inlineNpm.ts",
         inlineJsr: "inlineJsr.ts",
         inlineHttp: "inlineHttp.ts",

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -41,6 +41,10 @@ describe("Deno plugin", () => {
   });
 
   describe("inline", () => {
+    it("resolves external:", async () => {
+      await runTest(`inlineExternal.js`);
+    });
+
     it("resolves npm:", async () => {
       await runTest(`inlineNpm.js`);
     });


### PR DESCRIPTION
When a module tries to load `\0vite/preload-helper.js` this module throws an error.

This PR skips trying to load that module with deno and lets vite handle it.