### PR TITLE
Draft: Support npm: specifiers in @jsxImportSource pragma

### DIFF
--- a/src/prefixPlugin.ts
+++ b/src/prefixPlugin.ts
@@ -30,5 +30,16 @@ export default function denoPrefixPlugin(
         return await resolveViteSpecifier(id, cache, root, importer);
       }
     },
+    transform(code, id) {
+      if (!id.endsWith(".jsx") && !id.endsWith(".tsx")) return;
+
+      const match = code.match(
+        /\/\*\*\s*@jsxImportSource\s+npm:(@?[^@\s*]+)([^\s*]*)\s*\*\//,
+      );
+
+      if (match) {
+        return code.replace(match[0], `/** @jsxImportSource ${match[1]} */`);
+      }
+    },
   };
 }

--- a/tests/fixture/jsx.tsx
+++ b/tests/fixture/jsx.tsx
@@ -1,0 +1,10 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource npm:preact@^10.24.0 */
+
+function App() {
+  return <div>hello world</div>;
+}
+
+App();
+
+console.log("it works");

--- a/tests/fixture/vite.config.ts
+++ b/tests/fixture/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         inlineNpm: "inlineNpm.ts",
         inlineJsr: "inlineJsr.ts",
         inlineHttp: "inlineHttp.ts",
+        jsx: "jsx.tsx",
         resolveInRootDir: "resolveInRootDir.ts",
       },
     },

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -66,4 +66,8 @@ describe("Deno plugin", () => {
   it("resolve to file in root dir", async () => {
     await runTest(`resolveInRootDir.js`);
   });
+
+  it("resolves @jsxImportSource with npm: prefix", async () => {
+    await runTest(`jsx.js`);
+  });
 });


### PR DESCRIPTION
Currently if you try to use a JSX component from a JSR package in Deno+Vite, you will get an error: `Uncaught TypeError: jsx is not a function`

This fixes the ability to import JSX components from JSR and use them with Vite. Currently JSR does not transpile JSX components and instead inserts pragma directives like `/** @jsxImportSource npm:preact */`, which Vite cannot resolve.

See: https://github.com/jsr-io/jsr/issues/24#issuecomment-2795586514

I did a lot of experimentation, and found that when you have a pragma like this:

```tsx
/** @jsxImportSource npm:preact@^10.24.0 */
```

it is never intercepted by the Vite plugin system. It's never passed to `resolveId`. The only way to make it work is to modify the source code file before Vite's JSX loader transforms it.

So I did a simple regex replace to just strip the `npm:` identifier and `@` version because Vite doesn't utilize it anyway. It doesn't seem worth doing full module resolution here because Vite expects a plain npm package name (I'm not 100% sure about that, but I couldn't get it to work with an absolute path in my tests). So just stripping it seems like the best workaround for now.