### PR TITLE
fix: introduce lock around `deno info` calls to fix OOM (#50)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,11 @@ import { Plugin } from "vite";
 import prefixPlugin from "./prefixPlugin.js";
 import mainPlugin from "./resolvePlugin.js";
 import { DenoResolveResult } from "./resolver.js";
+import Lock from "./lock.js";
 
 export default function deno(): Plugin[] {
   const cache = new Map<string, DenoResolveResult>();
+  const lock = new Lock();
 
-  return [prefixPlugin(cache), mainPlugin(cache)];
+  return [prefixPlugin(cache, lock), mainPlugin(cache, lock)];
 }

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,0 +1,32 @@
+export default class Lock {
+  private locked: boolean = false;
+  private waitQueue: Array<() => void> = [];
+
+  acquire(): Promise<void> {
+    // If lock is not currently held, acquire it immediately
+    if (!this.locked) {
+      this.locked = true;
+      return Promise.resolve();
+    }
+
+    // Otherwise, wait for the lock to be released
+    return new Promise<void>((resolve) => {
+      this.waitQueue.push(resolve);
+    });
+  }
+
+  release(): void {
+    if (!this.locked) {
+      throw new Error("Cannot release a lock that is not held");
+    }
+
+    // If there are waiters, resolve the next one in queue
+    if (this.waitQueue.length > 0) {
+      const nextResolver = this.waitQueue.shift()!;
+      nextResolver();
+    } else {
+      // Otherwise, mark the lock as free
+      this.locked = false;
+    }
+  }
+}

--- a/src/prefixPlugin.ts
+++ b/src/prefixPlugin.ts
@@ -5,9 +5,11 @@ import {
   resolveViteSpecifier,
 } from "./resolver.js";
 import process from "node:process";
+import Lock from "./lock.js";
 
 export default function denoPrefixPlugin(
   cache: Map<string, DenoResolveResult>,
+  lock: Lock,
 ): Plugin {
   let root = process.cwd();
 
@@ -19,7 +21,7 @@ export default function denoPrefixPlugin(
     },
     async resolveId(id, importer) {
       if (id.startsWith("npm:")) {
-        const resolved = await resolveDeno(id, root);
+        const resolved = await resolveDeno(id, root, lock);
         if (resolved === null) return;
 
         // TODO: Resolving custom versions is not supported at the moment
@@ -27,7 +29,7 @@ export default function denoPrefixPlugin(
         const result = await this.resolve(actual);
         return result ?? actual;
       } else if (id.startsWith("http:") || id.startsWith("https:")) {
-        return await resolveViteSpecifier(id, cache, root, importer);
+        return await resolveViteSpecifier(id, cache, root, lock, importer);
       }
     },
   };

--- a/src/resolvePlugin.ts
+++ b/src/resolvePlugin.ts
@@ -9,9 +9,11 @@ import {
 import { type Loader, transform } from "esbuild";
 import * as fsp from "node:fs/promises";
 import process from "node:process";
+import Lock from "./lock.js";
 
 export default function denoPlugin(
   cache: Map<string, DenoResolveResult>,
+  lock: Lock,
 ): Plugin {
   let root = process.cwd();
 
@@ -24,7 +26,7 @@ export default function denoPlugin(
       // The "pre"-resolve plugin already resolved it
       if (isDenoSpecifier(id)) return;
 
-      return await resolveViteSpecifier(id, cache, root, importer);
+      return await resolveViteSpecifier(id, cache, root, lock, importer);
     },
     async load(id) {
       if (!isDenoSpecifier(id)) return;


### PR DESCRIPTION


edit (2025-05-26): 

For what it's worth: 

We've forked this at https://github.com/masslbs/deno-vite-plugin and published the fork so that it can be used by ci: https://www.npmjs.com/package/@masslbs/deno-vite-plugin

Info from the [fork's README](https://github.com/masslbs/deno-vite-plugin):

> Care has been taken to avoid introducing changes in the final output arrived at by running this version of `deno-vite-plugin` compared to the upstream version. The result of this fork is that it uses a bounded amount of memory and its execution time is faster after a first run has populated the cache.
> 
> This fork: 
> * uses a lock to limit external calls to `deno info --json` 
> * improves how the in-memory cache is used by catching more cases
> *  implements an on-disk cache, speeding up initial loading considerably
> 
> The on-disk cache is only written after a clean exit from vite, or when the server restarts as that is when [Rollup's buildEnd](https://rollupjs.org/plugin-development/#buildend) phase runs.
>  
> Prevent the on-disk cache from being used by setting the environment variable `NOCACHE` e.g. `NOCACHE="1" deno run dev`. This can be helpful if debugging any build errors that may/may not have to do with caching.
> 
> Logging what the plugin is doing at any point in time can be enabled by providing `DEBUG=deno-vite-plugin` or `DEBUG=*`. 





---



This fix builds on the insight in #55 but does so by performing the minimal change required to fix the underlying issue. The reason for this departure from #55 is due to our project's build failing when executed using the proof of concept's plugin, presumably due to some unknown change introduced on part of the proof of concept's extensive revision.

The fix reuses @notcome's lock component and threads said lock through the codebase to ultimately place it around the `deno info --json ${id}` calls.

When building our project using this patch of the plugin, my CPU utilization never goes about ~30% and the memory usage stays more or less constant. This is compare to before, where CPU utilization hit 100% and I ran out of memory and my system froze.

Fixes #50 and closes https://github.com/masslbs/Tennessine/issues/330

---
For reviewers:

* I license the changes I've introduced under the same license as `deno-vite-plugin` itself i.e. MIT; @notcome could you let me know whether you license my usage of your `Lock` class under MIT as well?
* I'm open to introducing a semaphore to allow for a configurable degree of parallelism. In that case I would import https://www.npmjs.com/package/async-mutex and use its semaphore implementation.