### PR TITLE
chore: updated vite peer dependency to v7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "vite": "5.x || 6.x"
+    "vite": "5.x || 6.x || 7.x"
   },
   "devDependencies": {
     "@types/node": "^22.5.5",


### PR DESCRIPTION
Updates peer dependency of vite to accept vite v7.x.  Supresses a warning during deno install
<img width="709" height="91" alt="image" src="https://github.com/user-attachments/assets/7dc16808-5b50-4987-8a86-3f15834643f1" />
