### PR TITLE
fix: no field roots shown when package absents

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -45,7 +45,7 @@ interface ResolveError {
 interface DenoInfoJsonV1 {
   version: 1;
   redirects: Record<string, string>;
-  roots: string[];
+  roots?: string[];
   modules: Array<
     NpmResolvedInfo | ResolvedInfo | ExternalResolvedInfo | ResolveError
   >;
@@ -100,6 +100,10 @@ export async function resolveDeno(
   if (output === null) return null;
 
   const json = JSON.parse(output) as DenoInfoJsonV1;
+  if(!('roots' in json)) {
+    return null
+  }
+
   const actualId = json.roots[0];
 
   // Find the final resolved cache path. First, we need to check


### PR DESCRIPTION
Somehow, the field roots doesn't appear in the json output of deno info --json,

https://github.com/denoland/deno/blob/main/cli/tools/info.rs#L209-L214