### PR TITLE
chore: release 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deno/vite-plugin",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "license": "MIT",
   "exports": {


### PR DESCRIPTION
Updating version to 1.0.6 to include vite 7 as a peer dependency