### PR TITLE
ci: declare contents:read on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins `ci.yml` to `contents: read` at workflow scope. Both jobs (`lint-and-format`, `test`) only check out, install deno + node, and run `deno fmt`/`deno lint` and `npm install vite@... && npm run build`. No GitHub API write.

Defense-in-depth motivation is [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) on `tj-actions/changed-files`: a compromised third-party action runs inside the existing job context and exfiltrates the workflow `GITHUB_TOKEN` via build logs. `denoland/setup-deno` and `actions/setup-node` are third-party here, so the cap is meaningful.

Style matches the per-job block in `release.yml`. YAML validated locally with `yaml.safe_load`.