### PR TITLE
fix: honor workspace-member-scoped import maps

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -190,28 +190,53 @@ export async function resolveViteSpecifier(
     }
   }
 
-  if (importer && isDenoSpecifier(importer)) {
+  // Resolve relative to the importer so that a workspace member's own import
+  // map is honored. A member's `imports` are *scoped* to that member's
+  // directory (e.g. an "@ui/" alias or a jsr:/npm: dependency declared in the
+  // member's deno.json), so they are only resolvable when the referrer is
+  // known. Vite hands us two kinds of importer:
+  //  - one of our virtual Deno specifiers (a sub-import of a Deno module), or
+  //  - a plain file path. This happens when a Deno module re-exports a local
+  //    file: the file is returned to Vite as a real path (below), so its own
+  //    imports arrive here with a plain-path importer and no Deno context.
+  const importerIsDeno = importer !== undefined && isDenoSpecifier(importer);
+  let parentUrl: string | undefined;
+  if (importerIsDeno) {
     const { resolved: parent } = parseDenoSpecifier(importer);
+    parentUrl = parent.startsWith("/") ? pathToFileURL(parent).href : parent;
+  } else if (
+    importer !== undefined && !id.startsWith(".") && !id.startsWith("/")
+  ) {
+    // Only bare/aliased specifiers consult the import map; relative and
+    // absolute specifiers are left to Vite's default resolver, as before.
+    const importerPath = importer.split("?")[0];
+    if (path.isAbsolute(importerPath)) {
+      parentUrl = pathToFileURL(importerPath).href;
+    }
+  }
 
-    // Resolve the sub-import relative to its parent module
-    const parentUrl = parent.startsWith("/")
-      ? pathToFileURL(parent).href
-      : parent;
-
-    let resolvedUrl: string;
+  if (parentUrl !== undefined) {
+    let resolvedUrl: string | undefined;
     try {
       resolvedUrl = loader.resolveSync(id, parentUrl, ResolutionMode.Import);
     } catch (err) {
-      if (err instanceof ResolveError) return;
-      throw err;
+      if (!(err instanceof ResolveError)) throw err;
+      // For our own virtual specifiers a ResolveError is terminal. For a
+      // plain-file importer, fall through to the referrer-less resolution
+      // below so root-scoped resolution still gets a chance.
+      if (importerIsDeno) return;
     }
 
-    if (resolvedUrl.startsWith("file://")) {
-      return fileURLToPath(resolvedUrl);
+    if (resolvedUrl !== undefined) {
+      // Preserve existing behavior for sub-imports of Deno modules: an
+      // in-graph file path is returned to Vite directly. For a plain-file
+      // importer, feed the resolved specifier through the shared path below
+      // so in-/out-of-root handling and media-type wrapping still apply.
+      if (importerIsDeno && resolvedUrl.startsWith("file://")) {
+        return fileURLToPath(resolvedUrl);
+      }
+      id = resolvedUrl;
     }
-
-    // Continue resolution for non-file URLs (e.g. https:)
-    id = resolvedUrl;
   }
 
   const resolved = cache.get(id) ?? await resolveDeno(id, loader);

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -158,6 +158,34 @@ export async function resolveDeno(
   };
 }
 
+/**
+ * Compute a file:// referrer URL for a *plain-file* importer, so that a
+ * bare/aliased specifier can be resolved against the importing file's
+ * workspace-member import map. Returns undefined when the importer is not a
+ * real project source that should carry a member scope.
+ *
+ * Only bare/aliased specifiers consult the import map, so relative and
+ * absolute specifiers are left to Vite. Vite's own virtual/URL-ish ids
+ * ("/@fs/…", "/@id/…", "\0…") are not real paths, and dependencies under
+ * node_modules must keep resolving through Vite's pipeline rather than being
+ * reinterpreted against a nested deno.json — both are excluded.
+ */
+function memberReferrerUrl(
+  id: string,
+  importer: string | undefined,
+): string | undefined {
+  if (importer === undefined || isDenoSpecifier(importer)) return undefined;
+  if (id.startsWith(".") || id.startsWith("/")) return undefined;
+
+  const importerPath = importer.split("?")[0];
+  if (!path.isAbsolute(importerPath) || importerPath.startsWith("/@")) {
+    return undefined;
+  }
+  if (importerPath.includes("/node_modules/")) return undefined;
+
+  return pathToFileURL(importerPath).href;
+}
+
 export async function resolveViteSpecifier(
   id: string,
   cache: Map<string, DenoResolveResult>,
@@ -167,11 +195,33 @@ export async function resolveViteSpecifier(
 ) {
   const root = path.normalize(posixRoot);
 
+  // When a Deno module re-exports a local file, that file is handed back to
+  // Vite as a plain path (see the isInsideRoot branch below), so its own
+  // imports arrive here with a plain-path importer and no Deno context.
+  // Resolve bare/aliased specifiers relative to that importer so a workspace
+  // member's own import map is honored: a member's `imports` are *scoped* to
+  // that member's directory (e.g. an "@ui/" alias, or a jsr:/npm: dependency
+  // declared in the member's deno.json), so they are only resolvable when the
+  // referrer is known. This runs before the import.meta.resolve heuristic
+  // below so a member-scoped entry wins over the root map on a name collision.
+  const referrerUrl = memberReferrerUrl(id, importer);
+  let referrerResolved = false;
+  if (referrerUrl !== undefined) {
+    try {
+      id = loader.resolveSync(id, referrerUrl, ResolutionMode.Import);
+      referrerResolved = true;
+    } catch (err) {
+      if (!(err instanceof ResolveError)) throw err;
+      // Not in the member scope either — fall through to the referrer-less
+      // resolution below so the root map still gets a chance.
+    }
+  }
+
   // Resolve import map — when running under Deno, import.meta.resolve
   // consults the import map from deno.json, allowing bare specifiers
   // (e.g. "preact") to be mapped to "npm:preact@^10". Under Node.js this
   // falls back to Node's own resolution (package.json imports/exports).
-  if (!id.startsWith(".") && !id.startsWith("/")) {
+  if (!referrerResolved && !id.startsWith(".") && !id.startsWith("/")) {
     try {
       const resolved = import.meta.resolve(id);
       // Only use the result if it's a scheme the loader understands.
@@ -190,53 +240,28 @@ export async function resolveViteSpecifier(
     }
   }
 
-  // Resolve relative to the importer so that a workspace member's own import
-  // map is honored. A member's `imports` are *scoped* to that member's
-  // directory (e.g. an "@ui/" alias or a jsr:/npm: dependency declared in the
-  // member's deno.json), so they are only resolvable when the referrer is
-  // known. Vite hands us two kinds of importer:
-  //  - one of our virtual Deno specifiers (a sub-import of a Deno module), or
-  //  - a plain file path. This happens when a Deno module re-exports a local
-  //    file: the file is returned to Vite as a real path (below), so its own
-  //    imports arrive here with a plain-path importer and no Deno context.
-  const importerIsDeno = importer !== undefined && isDenoSpecifier(importer);
-  let parentUrl: string | undefined;
-  if (importerIsDeno) {
+  if (importer && isDenoSpecifier(importer)) {
     const { resolved: parent } = parseDenoSpecifier(importer);
-    parentUrl = parent.startsWith("/") ? pathToFileURL(parent).href : parent;
-  } else if (
-    importer !== undefined && !id.startsWith(".") && !id.startsWith("/")
-  ) {
-    // Only bare/aliased specifiers consult the import map; relative and
-    // absolute specifiers are left to Vite's default resolver, as before.
-    const importerPath = importer.split("?")[0];
-    if (path.isAbsolute(importerPath)) {
-      parentUrl = pathToFileURL(importerPath).href;
-    }
-  }
 
-  if (parentUrl !== undefined) {
-    let resolvedUrl: string | undefined;
+    // Resolve the sub-import relative to its parent module
+    const parentUrl = parent.startsWith("/")
+      ? pathToFileURL(parent).href
+      : parent;
+
+    let resolvedUrl: string;
     try {
       resolvedUrl = loader.resolveSync(id, parentUrl, ResolutionMode.Import);
     } catch (err) {
-      if (!(err instanceof ResolveError)) throw err;
-      // For our own virtual specifiers a ResolveError is terminal. For a
-      // plain-file importer, fall through to the referrer-less resolution
-      // below so root-scoped resolution still gets a chance.
-      if (importerIsDeno) return;
+      if (err instanceof ResolveError) return;
+      throw err;
     }
 
-    if (resolvedUrl !== undefined) {
-      // Preserve existing behavior for sub-imports of Deno modules: an
-      // in-graph file path is returned to Vite directly. For a plain-file
-      // importer, feed the resolved specifier through the shared path below
-      // so in-/out-of-root handling and media-type wrapping still apply.
-      if (importerIsDeno && resolvedUrl.startsWith("file://")) {
-        return fileURLToPath(resolvedUrl);
-      }
-      id = resolvedUrl;
+    if (resolvedUrl.startsWith("file://")) {
+      return fileURLToPath(resolvedUrl);
     }
+
+    // Continue resolution for non-file URLs (e.g. https:)
+    id = resolvedUrl;
   }
 
   const resolved = cache.get(id) ?? await resolveDeno(id, loader);

--- a/tests/fixture/deno.lock
+++ b/tests/fixture/deno.lock
@@ -834,7 +834,11 @@
       "npm:preact@^10.24.0"
     ],
     "links": {
-      "jsr:linked": {}
+      "jsr:linked": {
+        "dependencies": [
+          "jsr:@std/encoding@^1.0.5"
+        ]
+      }
     }
   }
 }

--- a/tests/fixture/linking.ts
+++ b/tests/fixture/linking.ts
@@ -1,5 +1,9 @@
 import { linkedFunction } from "linked";
 
-if (typeof linkedFunction === "function") {
+// Call it at runtime: linkedFunction is implemented in the linked package via
+// its own member-scoped imports (an "@linked/" alias and the "@std/encoding"
+// jsr dependency), so a correct result proves those resolved and executed, not
+// just that the build succeeded. "aGVscGVy" is base64("helper").
+if (typeof linkedFunction === "function" && linkedFunction() === "aGVscGVy") {
   console.log("it works");
 }

--- a/tests/linked/deno.json
+++ b/tests/linked/deno.json
@@ -2,5 +2,9 @@
   "name": "linked",
   "exports": {
     ".": "./main.ts"
+  },
+  "imports": {
+    "@linked/": "./",
+    "@std/encoding": "jsr:@std/encoding@^1.0.5"
   }
 }

--- a/tests/linked/sub.ts
+++ b/tests/linked/sub.ts
@@ -9,5 +9,7 @@ import { helper } from "@linked/util.ts";
 import { encodeBase64 } from "@std/encoding/base64";
 
 export function linkedFunction() {
+  // helper() -> "helper"; both imports must resolve and run for the expected
+  // result, so a break in either is observable at runtime, not just at build.
   return encodeBase64(new TextEncoder().encode(helper()));
 }

--- a/tests/linked/sub.ts
+++ b/tests/linked/sub.ts
@@ -1,3 +1,13 @@
 // This is a dummy file to test the linked module functionality.
+//
+// The two imports below exercise the linked package's *own* (member-scoped)
+// import map: "@linked/" is an alias and "@std/encoding" is a jsr dependency,
+// neither of which exists in the root import map. main.ts re-exports this file,
+// so Vite processes it with a plain-path importer — the case that regressed
+// member-scoped resolution.
+import { helper } from "@linked/util.ts";
+import { encodeBase64 } from "@std/encoding/base64";
 
-export function linkedFunction() {}
+export function linkedFunction() {
+  return encodeBase64(new TextEncoder().encode(helper()));
+}

--- a/tests/linked/util.ts
+++ b/tests/linked/util.ts
@@ -1,0 +1,4 @@
+// Alias target for the linked package's own "@linked/" import map entry.
+export function helper(): string {
+  return "helper";
+}

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -85,4 +85,12 @@ describe("Deno plugin", () => {
   it("resolve to file in root dir", async () => {
     await runTest(`resolveInRootDir.js`);
   });
+
+  // A linked/workspace member resolved via the root map is handed to Vite as a
+  // plain path, so its own imports must still resolve against the member's own
+  // (directory-scoped) import map — an "@linked/" alias and a jsr dependency
+  // that are absent from the root map.
+  it("resolves a member's own scoped import map", async () => {
+    await runTest(`linking.js`);
+  });
 });


### PR DESCRIPTION
A monorepo where a workspace member (`packages/config`, `packages/ui`, …)
is imported by a Vite app fails to resolve any import that relies on the
member's *own* import map — an aliased import (e.g. `@ui/`) or a `jsr:`
dependency declared in that member's `deno.json`. Vite reports
`Failed to resolve import` for the alias case and `Cannot find module`
for the jsr case, even though the same imports work under plain Deno.

The cause is in `resolveViteSpecifier`. When a Deno module re-exports a
local file, the plugin returns that file to Vite as a plain path,
dropping its Deno context. Vite then processes the file and resolves its
imports with a plain-path importer, so the plugin fell to the
referrer-less path:

```js
loader.resolveSync(id, undefined, ResolutionMode.Import);
```

A workspace member's `imports` are *scoped* to that member's directory,
so without a referrer the loader only consults the root import map —
where the alias / member-local jsr dependency does not exist. Both
reported failures are this one root cause.

The fix resolves bare/aliased specifiers relative to the importing file
(via `memberReferrerUrl`), so member-scoped maps are honored. It runs
before the `import.meta.resolve` heuristic and on the original specifier,
so a member-scoped entry wins over the root map on a name collision.
Guards keep the blast radius tight:

- relative and absolute specifiers are still left to Vite's resolver;
- importers under `node_modules` and Vite's virtual/URL-ish ids
  (`/@fs/…`, `/@id/…`, `\0…`) are excluded, so dependency resolution and
  Vite internals are untouched;
- the existing Deno-specifier importer path is byte-for-byte unchanged;
- a referrer miss falls through to the previous behavior.

### Tests

The `linked` fixture gains a member-scoped alias (`@linked/`) and a jsr
import (`@std/encoding`), neither present in the root map. The linked
module is now executed at runtime (a new `dist/linking.js` test case
calls `linkedFunction()` and asserts its value), so the member-scoped
imports are validated at runtime, not just at build. With the fix
reverted the fixture build fails with the same `Failed to resolve import`
error; with the fix all tests pass.

Verified end-to-end against a real reproduction repo: the app builds with
the patched plugin and fails with the released one.

### Not covered (follow-up)

npm dependencies declared in a *member's* import map are a separate,
deeper issue and are intentionally left out of scope. An npm specifier
resolved from a linked/member package returns `kind: "npm"`, so the
plugin hands it back to Vite, whose node resolution then looks from the
member's directory rather than the app's `node_modules` and fails.
Fixing that requires resolving the npm specifier to disk inside the main
plugin (as `prefixPlugin` already does for `npm:`-prefixed ids), which is
best done in its own change.