### PR TITLE
chore: release 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deno/vite-plugin",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deno/vite-plugin",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@deno/loader": "npm:@jsr/deno__loader@^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deno/vite-plugin",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "license": "MIT",
   "exports": {


### PR DESCRIPTION
Release 2.0.3.

Bumps `package.json` / `package-lock.json` from 2.0.2 to 2.0.3. Once
merged, publishing a `2.0.3` GitHub Release triggers the npm publish
workflow.

Changes since 2.0.2:

- fix: honor workspace-member-scoped import maps (#102) — a workspace
  member's own aliased (`@ui/`) and jsr imports now resolve when the
  member is consumed by a Vite app, instead of failing with
  "Failed to resolve import" / "Cannot find module".