### PR TITLE
ci: publish to npm via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required for npm trusted publishing (OIDC): lets the job mint the
+      # short-lived OIDC token npm exchanges for publish access. No NPM_TOKEN.
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
+          # Trusted publishing requires Node >= 22.14.0.
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
+      # Trusted publishing requires npm CLI >= 11.5.1; Node 22 still bundles
+      # npm 10, so upgrade before publishing.
+      - run: npm install -g npm@latest
       - run: npm ci
+      # No NODE_AUTH_TOKEN: npm authenticates via OIDC and generates
+      # provenance automatically. Requires a trusted publisher configured for
+      # this package on npmjs.com pointing at this repo's release.yml workflow.
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Switch the npm publish workflow from a long-lived `NPM_TOKEN` secret to
npm trusted publishing (OIDC), which also generates provenance
attestations automatically.

Changes:

- Drop `NODE_AUTH_TOKEN` / the `NPM_TOKEN` secret from the publish step —
  npm authenticates via the GitHub Actions OIDC token instead. The
  `id-token: write` permission was already present.
- Upgrade the npm CLI before publishing: trusted publishing needs npm
  >= 11.5.1, but Node 22 still bundles npm 10.

Requires a one-time setup on npmjs.com: configure a trusted publisher for
`@deno/vite-plugin` pointing at `denoland/deno-vite-plugin`, workflow
`release.yml` (no environment). Once that is in place, publishing the
`2.0.3` GitHub Release publishes via OIDC with no stored token.

Motivation: the `NPM_TOKEN`-based publish has been failing with `E404` on
publish (an expired/invalid token), which blocked the 2.0.3 release.