### PR TITLE
ci: run npm ci before upgrading npm for OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,13 @@ jobs:
           # Trusted publishing requires Node >= 22.14.0.
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
-      # Trusted publishing requires npm CLI >= 11.5.1; Node 22 still bundles
-      # npm 10, so upgrade before publishing.
-      - run: npm install -g npm@latest
+      # Install with the bundled npm (10): the lockfile records this package's
+      # jsr dependencies as remote (npm.jsr.io) tarballs, which npm >= 12
+      # refuses to fetch (EALLOWREMOTE). Do this before upgrading npm.
       - run: npm ci
+      # Upgrade npm only for the publish step: trusted publishing (OIDC)
+      # requires npm CLI >= 11.5.1, but Node 22 still bundles npm 10.
+      - run: npm install -g npm@latest
       # No NODE_AUTH_TOKEN: npm authenticates via OIDC and generates
       # provenance automatically. Requires a trusted publisher configured for
       # this package on npmjs.com pointing at this repo's release.yml workflow.


### PR DESCRIPTION
Follow-up to #104. The trusted-publishing workflow upgraded npm to the
latest (12.x) before `npm ci`, but npm >= 12 refuses to fetch "remote"
tarballs (`EALLOWREMOTE`), and this package's jsr dependencies
(`@std/jsonc`, `@deno/loader`) are recorded in the lockfile as
`npm.jsr.io` remote URLs. The install therefore failed:

```
npm error code EALLOWREMOTE
npm error Fetching packages of type "remote" have been disabled
npm error Refusing to fetch "@std/jsonc@https://npm.jsr.io/~/11/@jsr/std__jsonc/1.0.2.tgz"
```

Run `npm ci` first, under Node 22's bundled npm 10 (which allows those
remotes — this is how 2.0.2 published), and upgrade npm only afterwards
so the publish step still gets the npm >= 11.5.1 required for OIDC.